### PR TITLE
Fix verbose output

### DIFF
--- a/runner/output_writer.go
+++ b/runner/output_writer.go
@@ -11,9 +11,14 @@ import (
 )
 
 type OutputWriter struct {
-	cache   *lru.Cache
-	writers []io.Writer
+	cache        *lru.Cache
+	namedWriters []NamedWriter
 	sync.RWMutex
+}
+
+type NamedWriter struct {
+	Writer io.Writer
+	Name   string
 }
 
 func NewOutputWriter() (*OutputWriter, error) {
@@ -24,19 +29,36 @@ func NewOutputWriter() (*OutputWriter, error) {
 	return &OutputWriter{cache: lastPrintedCache}, nil
 }
 
-func (o *OutputWriter) AddWriters(writers ...io.Writer) {
-	o.writers = append(o.writers, writers...)
+func (o *OutputWriter) AddWriters(named ...NamedWriter) {
+	o.namedWriters = append(o.namedWriters, named...)
 }
 
-func (o *OutputWriter) Write(data []byte) {
+// WriteAll writes the data taken as input using
+// all the writers.
+func (o *OutputWriter) WriteAll(data []byte) {
 	o.Lock()
 	defer o.Unlock()
 
-	for _, writer := range o.writers {
-		_, _ = writer.Write(data)
-		_, _ = writer.Write([]byte("\n"))
+	for _, w := range o.namedWriters {
+		w.Writer.Write(data)
+		w.Writer.Write([]byte("\n"))
 	}
 }
+
+// Write writes the data taken as input using only
+// the writer(s) with that name.
+func (o *OutputWriter) Write(data []byte, name string) {
+	o.Lock()
+	defer o.Unlock()
+
+	for _, w := range o.namedWriters {
+		if w.Name == name {
+			w.Writer.Write(data)
+			w.Writer.Write([]byte("\n"))
+		}
+	}
+}
+
 func (o *OutputWriter) findDuplicate(data string) bool {
 	// check if we've already printed this data
 	itemHash := sha1.Sum([]byte(data))
@@ -47,15 +69,30 @@ func (o *OutputWriter) findDuplicate(data string) bool {
 	return false
 }
 
-func (o *OutputWriter) WriteString(data string) {
+// WriteString writes the string taken as input using only
+// the writer(s) with that name.
+// If name is empty it writes using all the writers.
+func (o *OutputWriter) WriteString(data string, name string) {
 	if o.findDuplicate(data) {
 		return
 	}
-	o.Write([]byte(data))
+	if name != "" {
+		o.Write([]byte(data), name)
+		return
+	}
+	o.WriteAll([]byte(data))
 }
-func (o *OutputWriter) WriteJsonData(data uncover.Result) {
+
+// WriteJsonData writes the result taken as input in JSON format
+// using only the writer(s) with that name.
+// If name is empty it writes using all the writers.
+func (o *OutputWriter) WriteJsonData(data uncover.Result, name string) {
 	if o.findDuplicate(fmt.Sprintf("%s:%d", data.IP, data.Port)) {
 		return
 	}
-	o.Write([]byte(data.JSON()))
+	if name != "" {
+		o.Write([]byte(data.JSON()), name)
+		return
+	}
+	o.WriteAll([]byte(data.JSON()))
 }

--- a/runner/output_writer.go
+++ b/runner/output_writer.go
@@ -47,7 +47,7 @@ func (o *OutputWriter) WriteAll(data []byte) {
 
 // Write writes the data taken as input using only
 // the writer(s) with that name.
-func (o *OutputWriter) Write(data []byte, name string) {
+func (o *OutputWriter) Write(name string, data []byte) {
 	o.Lock()
 	defer o.Unlock()
 
@@ -72,12 +72,12 @@ func (o *OutputWriter) findDuplicate(data string) bool {
 // WriteString writes the string taken as input using only
 // the writer(s) with that name.
 // If name is empty it writes using all the writers.
-func (o *OutputWriter) WriteString(data string, name string) {
+func (o *OutputWriter) WriteString(name string, data string) {
 	if o.findDuplicate(data) {
 		return
 	}
 	if name != "" {
-		o.Write([]byte(data), name)
+		o.Write(name, []byte(data))
 		return
 	}
 	o.WriteAll([]byte(data))
@@ -86,12 +86,12 @@ func (o *OutputWriter) WriteString(data string, name string) {
 // WriteJsonData writes the result taken as input in JSON format
 // using only the writer(s) with that name.
 // If name is empty it writes using all the writers.
-func (o *OutputWriter) WriteJsonData(data uncover.Result, name string) {
+func (o *OutputWriter) WriteJsonData(name string, data uncover.Result) {
 	if o.findDuplicate(fmt.Sprintf("%s:%d", data.IP, data.Port)) {
 		return
 	}
 	if name != "" {
-		o.Write([]byte(data.JSON()), name)
+		o.Write(name, []byte(data.JSON()))
 		return
 	}
 	o.WriteAll([]byte(data.JSON()))

--- a/runner/output_writer.go
+++ b/runner/output_writer.go
@@ -40,8 +40,8 @@ func (o *OutputWriter) WriteAll(data []byte) {
 	defer o.Unlock()
 
 	for _, w := range o.namedWriters {
-		w.Writer.Write(data)
-		w.Writer.Write([]byte("\n"))
+		_, _ = w.Writer.Write(data)
+		_, _ = w.Writer.Write([]byte("\n"))
 	}
 }
 
@@ -53,8 +53,8 @@ func (o *OutputWriter) Write(data []byte, name string) {
 
 	for _, w := range o.namedWriters {
 		if w.Name == name {
-			w.Writer.Write(data)
-			w.Writer.Write([]byte("\n"))
+			_, _ = w.Writer.Write(data)
+			_, _ = w.Writer.Write([]byte("\n"))
 		}
 	}
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -170,10 +170,14 @@ func (r *Runner) Run(ctx context.Context, query ...string) error {
 						gologger.Warning().Label(agent.Name()).Msgf("%s\n", result.Error.Error())
 					case r.options.JSON:
 						gologger.Verbose().Label(agent.Name()).Msgf("%s\n", result.JSON())
-						outputWriter.WriteJsonData(result)
+						if !r.options.Verbose {
+							outputWriter.WriteJsonData(result)
+						}
 					case r.options.Raw:
 						gologger.Verbose().Label(agent.Name()).Msgf("%s\n", result.RawData())
-						outputWriter.WriteString(result.RawData())
+						if !r.options.Verbose {
+							outputWriter.WriteString(result.RawData())
+						}
 					default:
 						port := fmt.Sprint(result.Port)
 						replacer := strings.NewReplacer(
@@ -189,7 +193,9 @@ func (r *Runner) Run(ctx context.Context, query ...string) error {
 						// send to output if any of the field got replaced
 						if stringsutil.ContainsAny(outData, searchFor...) {
 							gologger.Verbose().Label(agent.Name()).Msgf("%s\n", outData)
-							outputWriter.WriteString(outData)
+							if !r.options.Verbose {
+								outputWriter.WriteString(outData)
+							}
 						}
 					}
 


### PR DESCRIPTION
Why does uncover print two times the output when in verbose mode?

Example:  
uncover v0.0.7  
Before PR
```
[shodan] 50.17.31.108:80
50.17.31.108:80
[shodan] 170.82.16.201:8086
170.82.16.201:8086
[shodan] 35.228.207.232:80
35.228.207.232:80
[shodan] 119.82.224.49:8086
119.82.224.49:8086
[shodan] 147.75.105.59:8081
147.75.105.59:8081
[shodan] 34.68.216.251:80
34.68.216.251:80
[shodan] 104.211.216.23:3000
104.211.216.23:3000
[shodan] 139.180.165.175:3000
139.180.165.175:3000
```

After PR:
```
[shodan] 50.17.31.108:80
[shodan] 170.82.16.201:8086
[shodan] 35.228.207.232:80
[shodan] 119.82.224.49:8086
[shodan] 147.75.105.59:8081
[shodan] 34.68.216.251:80
[shodan] 104.211.216.23:3000
[shodan] 139.180.165.175:3000
```