### PR TITLE
GH Action failing #102

### DIFF
--- a/.github/workflows/provider-integration.yml
+++ b/.github/workflows/provider-integration.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     name: Test Builds
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
This PR fixes the issue with the scheduled gh action provider test (ref: [Invalid workflow file: .github/workflows/provider-integration.yml#L9](https://github.com/edoardottt/uncover/actions/runs/3410411524/workflow)).

This PR closes #102. 