### PR TITLE
Fixing provider keys load

### DIFF
--- a/runner/options.go
+++ b/runner/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/gologger/formatter"
 	"github.com/projectdiscovery/gologger/levels"
+	"github.com/projectdiscovery/uncover/sources"
 	fileutil "github.com/projectdiscovery/utils/file"
 	folderutil "github.com/projectdiscovery/utils/folder"
 	genericutil "github.com/projectdiscovery/utils/generic"
@@ -78,7 +79,7 @@ func ParseOptions() *Options {
 	)
 
 	flagSet.CreateGroup("config", "Config",
-		flagSet.StringVarP(&options.ProviderFile, "provider", "pc", "", "provider configuration file"),
+		flagSet.StringVarP(&options.ProviderFile, "provider", "pc", sources.DefaultProviderConfigLocation, "provider configuration file"),
 		flagSet.StringVar(&options.ConfigFile, "config", defaultConfigLocation, "flag configuration file"),
 		flagSet.IntVar(&options.Timeout, "timeout", 30, "timeout in seconds"),
 		flagSet.IntVarP(&options.RateLimit, "rate-limit", "rl", 0, "maximum number of http requests to send per second"),
@@ -126,6 +127,10 @@ func ParseOptions() *Options {
 
 	if options.ConfigFile != defaultConfigLocation {
 		_ = options.loadConfigFrom(options.ConfigFile)
+	}
+
+	if options.ProviderFile != sources.DefaultProviderConfigLocation {
+		sources.DefaultProviderConfigLocation = options.ProviderFile
 	}
 
 	if genericutil.EqualsAll(0,
@@ -240,7 +245,6 @@ func appendQuery(options *Options, name string, queries ...string) {
 }
 
 func appendAllQueries(options *Options) {
-	var query []string = options.Query
 	appendQuery(options, "shodan", options.Shodan...)
 	appendQuery(options, "shodan-idb", options.ShodanIdb...)
 	appendQuery(options, "fofa", options.Fofa...)
@@ -252,5 +256,4 @@ func appendAllQueries(options *Options) {
 	appendQuery(options, "criminalip", options.CriminalIP...)
 	appendQuery(options, "publicwww", options.Publicwww...)
 	appendQuery(options, "hunterhow", options.HunterHow...)
-	options.Query = query
 }

--- a/sources/agent/quake/quake.go
+++ b/sources/agent/quake/quake.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/projectdiscovery/uncover/sources"
+	stringsutil "github.com/projectdiscovery/utils/strings"
 )
 
 const (
@@ -65,6 +66,11 @@ func (agent *Agent) query(URL string, session *sources.Session, quakeRequest *Re
 
 	quakeResponse := &Response{}
 	if err := json.NewDecoder(resp.Body).Decode(quakeResponse); err != nil {
+		// empty "data" == EOF
+		// the server returns "data":{} (object) when there are no more results (instead of "data":[] - slice)
+		if stringsutil.ContainsAnyI(err.Error(), "cannot unmarshal object into Go struct") {
+			return nil
+		}
 		results <- sources.Result{Source: agent.Name(), Error: err}
 		return nil
 	}

--- a/sources/agent/quake/quake.go
+++ b/sources/agent/quake/quake.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/projectdiscovery/uncover/sources"
+	errorutil "github.com/projectdiscovery/utils/errors"
 )
 
 const (
@@ -77,7 +78,7 @@ func (agent *Agent) query(URL string, session *sources.Session, quakeRequest *Re
 		return nil
 	}
 	if err := json.NewDecoder(bytes.NewReader(respdata)).Decode(quakeResponse); err != nil {
-		results <- sources.Result{Source: agent.Name(), Error: err}
+		results <- sources.Result{Source: agent.Name(), Error: errorutil.NewWithErr(err).Msgf("failed to decode quake response: %s", string(respdata))}
 		return nil
 	}
 

--- a/sources/agent/quake/response.go
+++ b/sources/agent/quake/response.go
@@ -18,7 +18,6 @@ type meta struct {
 }
 
 type Response struct {
-	Code    int            `json:"code"`
 	Data    []responseData `json:"data"`
 	Message string         `json:"message"`
 	Meta    meta           `json:"meta"`

--- a/sources/agent/quake/response.go
+++ b/sources/agent/quake/response.go
@@ -18,7 +18,5 @@ type meta struct {
 }
 
 type Response struct {
-	Data    []responseData `json:"data"`
-	Message string         `json:"message"`
-	Meta    meta           `json:"meta"`
+	Data []responseData `json:"data,omitempty"`
 }

--- a/sources/agent/quake/response.go
+++ b/sources/agent/quake/response.go
@@ -7,10 +7,10 @@ type responseData struct {
 }
 
 type pagination struct {
-	Count     int   `json:"count"`
-	PageIndex int   `json:"page_index"`
-	PageSize  int   `json:"page_size"`
-	Total     int64 `json:"total"`
+	Count     int `json:"count"`
+	PageIndex int `json:"page_index"`
+	PageSize  int `json:"page_size"`
+	Total     int `json:"total"`
 }
 
 type meta struct {
@@ -18,5 +18,7 @@ type meta struct {
 }
 
 type Response struct {
-	Data []responseData `json:"data,omitempty"`
+	Data    []responseData `json:"data"`
+	Message string         `json:"message"`
+	Meta    meta           `json:"meta"`
 }

--- a/sources/provider.go
+++ b/sources/provider.go
@@ -108,13 +108,13 @@ func (provider *Provider) LoadProviderKeysFromEnv() {
 		return arr
 	}
 	provider.Shodan = appendIfExists(provider.Shodan, "SHODAN_API_KEY")
-	provider.Hunter = appendIfExists(provider.Shodan, "HUNTER_API_KEY")
-	provider.Quake = appendIfExists(provider.Shodan, "QUAKE_TOKEN")
-	provider.ZoomEye = appendIfExists(provider.Shodan, "ZOOMEYE_API_KEY")
-	provider.Netlas = appendIfExists(provider.Shodan, "NETLAS_API_KEY")
-	provider.CriminalIP = appendIfExists(provider.Shodan, "CRIMINALIP_API_KEY")
-	provider.Publicwww = appendIfExists(provider.Shodan, "PUBLICWWW_API_KEY")
-	provider.HunterHow = appendIfExists(provider.Shodan, "HUNTERHOW_API_KEY")
+	provider.Hunter = appendIfExists(provider.Hunter, "HUNTER_API_KEY")
+	provider.Quake = appendIfExists(provider.Quake, "QUAKE_TOKEN")
+	provider.ZoomEye = appendIfExists(provider.ZoomEye, "ZOOMEYE_API_KEY")
+	provider.Netlas = appendIfExists(provider.Netlas, "NETLAS_API_KEY")
+	provider.CriminalIP = appendIfExists(provider.CriminalIP, "CRIMINALIP_API_KEY")
+	provider.Publicwww = appendIfExists(provider.Publicwww, "PUBLICWWW_API_KEY")
+	provider.HunterHow = appendIfExists(provider.HunterHow, "HUNTERHOW_API_KEY")
 
 	appendIfAllExists := func(arr []string, env1 string, env2 string) []string {
 		if val1, ok := os.LookupEnv(env1); ok {
@@ -127,7 +127,7 @@ func (provider *Provider) LoadProviderKeysFromEnv() {
 		return arr
 	}
 	provider.Fofa = appendIfAllExists(provider.Fofa, "FOFA_EMAIL", "FOFA_KEY")
-	provider.Fofa = appendIfAllExists(provider.Fofa, "CENSYS_API_ID", "CENSYS_API_SECRET")
+	provider.Censys = appendIfAllExists(provider.Censys, "CENSYS_API_ID", "CENSYS_API_SECRET")
 }
 
 // HasKeys returns true if at least one agent/source has keys


### PR DESCRIPTION
Closes #144 and potentially other issues related to missing/mixed api keys

```console
$ go run . -qk 'domain:\"google.com\"' -v -provider .\providers.yaml
...
quake] 113.108.239.253:443
[quake] 203.208.39.253:443
...
```