### PR TITLE
remove type assertion before type conversion

### DIFF
--- a/sources/agent/zoomeye/zoomeye.go
+++ b/sources/agent/zoomeye/zoomeye.go
@@ -91,7 +91,7 @@ func (agent *Agent) query(URL string, session *sources.Session, zoomeyeRequest *
 		}
 		if portinfo, ok := zoomeyeResult["portinfo"]; ok {
 			if port, ok := portinfo.(map[string]interface{}); ok {
-				result.Port = convertPortFromValue(port["port"].(float64))
+				result.Port = convertPortFromValue(port["port"])
 				if result.Port == 0 {
 					continue
 				}


### PR DESCRIPTION
This PR removes the unnecessary type assertion that occurs before the actual type conversion. Closes #219.