### PR TITLE
Add the ZOOMEYE_HOST environment variable.

### DIFF
--- a/sources/agent/zoomeye/zoomeye.go
+++ b/sources/agent/zoomeye/zoomeye.go
@@ -3,6 +3,7 @@ package zoomeye
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -12,7 +13,7 @@ import (
 	"github.com/projectdiscovery/uncover/sources"
 )
 
-const (
+var (
 	URL = "https://api.zoomeye.org/host/search?query=%s&page=%d"
 )
 
@@ -23,6 +24,10 @@ func (agent *Agent) Name() string {
 }
 
 func (agent *Agent) Query(session *sources.Session, query *sources.Query) (chan sources.Result, error) {
+	if session.Keys.ZoomEyeHost != "" {
+		URL = strings.Replace(URL, "zoomeye.org", session.Keys.ZoomEyeHost, 1)
+	}
+
 	if session.Keys.ZoomEyeToken == "" {
 		return nil, errors.New("empty zoomeye keys")
 	}

--- a/sources/keys.go
+++ b/sources/keys.go
@@ -8,6 +8,7 @@ type Keys struct {
 	FofaKey         string
 	QuakeToken      string
 	HunterToken     string
+	ZoomEyeHost     string
 	ZoomEyeToken    string
 	NetlasToken     string
 	CriminalIPToken string
@@ -23,6 +24,7 @@ func (keys Keys) Empty() bool {
 		keys.FofaKey == "" &&
 		keys.QuakeToken == "" &&
 		keys.HunterToken == "" &&
+		keys.ZoomEyeHost == "" &&
 		keys.ZoomEyeToken == "" &&
 		keys.NetlasToken == "" &&
 		keys.CriminalIPToken == "" &&

--- a/sources/provider.go
+++ b/sources/provider.go
@@ -77,7 +77,12 @@ func (provider *Provider) GetKeys() Keys {
 	}
 
 	if len(provider.ZoomEye) > 0 {
-		keys.ZoomEyeToken = provider.ZoomEye[rand.Intn(len(provider.ZoomEye))]
+		zoomeye := provider.ZoomEye[rand.Intn(len(provider.ZoomEye))]
+		parts := strings.Split(zoomeye, ":")
+		if len(parts) == 2 {
+			keys.ZoomEyeToken = parts[0]
+			keys.ZoomEyeHost = parts[1]
+		}
 	}
 
 	if len(provider.Netlas) > 0 {
@@ -120,7 +125,6 @@ func (provider *Provider) LoadProviderKeysFromEnv() {
 	provider.Shodan = appendIfExists(provider.Shodan, "SHODAN_API_KEY")
 	provider.Hunter = appendIfExists(provider.Hunter, "HUNTER_API_KEY")
 	provider.Quake = appendIfExists(provider.Quake, "QUAKE_TOKEN")
-	provider.ZoomEye = appendIfExists(provider.ZoomEye, "ZOOMEYE_API_KEY")
 	provider.Netlas = appendIfExists(provider.Netlas, "NETLAS_API_KEY")
 	provider.CriminalIP = appendIfExists(provider.CriminalIP, "CRIMINALIP_API_KEY")
 	provider.Publicwww = appendIfExists(provider.Publicwww, "PUBLICWWW_API_KEY")
@@ -136,6 +140,7 @@ func (provider *Provider) LoadProviderKeysFromEnv() {
 		}
 		return arr
 	}
+	provider.ZoomEye = appendIfAllExists(provider.ZoomEye, "ZOOMEYE_API_KEY", "ZOOMEYE_HOST")
 	provider.Fofa = appendIfAllExists(provider.Fofa, "FOFA_EMAIL", "FOFA_KEY")
 	provider.Censys = appendIfAllExists(provider.Censys, "CENSYS_API_ID", "CENSYS_API_SECRET")
 }


### PR DESCRIPTION
The ZoomEye team recently launched zoomeye.hk[1], and IPs outside China cannot use api.zoomeye.org, while IPs within China cannot use api.zoomeye.hk. In order to use zoomeye.hk and zoomeye.org flexibly, the ZOOMEYE_HOST environment variable has been added.

usage:

```
ZOOMEYE_HOST=zoomeye.org ZOOMEYE_API_KEY=<your key> uncover -ze <query keyword> -v
ZOOMEYE_HOST=zoomeye.hk ZOOMEYE_API_KEY=<your key> uncover -ze <query keyword> -v
```

- [1] https://twitter.com/zoomeye_team/status/1772107041651523891