### PR TITLE
Update golang version for builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base
-FROM golang:1.21.4-alpine AS builder
+FROM golang:1.24.1-alpine AS builder
 RUN apk add --no-cache git build-base
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
Fixed wrong version for builder stage being inferior to the go.mod version which leads to an error when trying to build an image.

See the error below.
```ShellSession
$ docker build -t uncover .
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon  2.155MB
Step 1/10 : FROM golang:1.21.4-alpine AS builder
 ---> 72d77ba3e25b
Step 2/10 : RUN apk add --no-cache git build-base
 ---> Using cache
 ---> 578d58ca3908
Step 3/10 : WORKDIR /app
 ---> Using cache
 ---> c9df7bb33baf
Step 4/10 : COPY . /app
 ---> 8a88f88d04bd
Step 5/10 : RUN go mod download
 ---> Running in 54b508e30337
go: go.mod requires go >= 1.22.0 (running go 1.21.4; GOTOOLCHAIN=local)
The command '/bin/sh -c go mod download' returned a non-zero code: 1
```

I changed the version of golang to 1.24.1 which successfully builds the 1.0.10 version of uncover.