### PR TITLE
fix duplicate output

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -89,10 +89,7 @@ func (r *Runner) Run(ctx context.Context) error {
 			}
 			if stringsutil.ContainsAny(outData, searchFor...) && !r.outputWriter.findDuplicate(outData, false) {
 				if r.options.Verbose {
-					// if output is verbose include source name
 					gologger.Info().Label(result.Source).Msg(outData)
-				} else {
-					gologger.DefaultLogger.Print().Msg(outData)
 				}
 				r.outputWriter.WriteString(outData)
 			}


### PR DESCRIPTION
closes https://github.com/projectdiscovery/uncover/issues/667 and https://github.com/projectdiscovery/uncover/issues/701


```console
$ echo 1.1.1.1 | go run . -e shodan-idb             

  __  ______  _________ _   _____  _____
 / / / / __ \/ ___/ __ \ | / / _ \/ ___/
/ /_/ / / / / /__/ /_/ / |/ /  __/ /    
\__,_/_/ /_/\___/\____/|___/\___/_/

                projectdiscovery.io

[INF] Current uncover version v1.1.0 (latest)
1.1.1.1:53
1.1.1.1:80
1.1.1.1:443
1.1.1.1:2082
1.1.1.1:2086
1.1.1.1:2087
1.1.1.1:8443
1.1.1.1:8880

$ echo 1.1.1.1 | go run . -e shodan-idb -v

  __  ______  _________ _   _____  _____
 / / / / __ \/ ___/ __ \ | / / _ \/ ___/
/ /_/ / / / / /__/ /_/ / |/ /  __/ /    
\__,_/_/ /_/\___/\____/|___/\___/_/

                projectdiscovery.io

[INF] Current uncover version v1.1.0 (latest)
[shodan-idb] 1.1.1.1:53
[shodan-idb] 1.1.1.1:80
[shodan-idb] 1.1.1.1:443
[shodan-idb] 1.1.1.1:2082
[shodan-idb] 1.1.1.1:2086
[shodan-idb] 1.1.1.1:2087
[shodan-idb] 1.1.1.1:8443
[shodan-idb] 1.1.1.1:8880

$ echo 1.1.1.1 | go run . -e shodan-idb -o ff.txt -v

  __  ______  _________ _   _____  _____
 / / / / __ \/ ___/ __ \ | / / _ \/ ___/
/ /_/ / / / / /__/ /_/ / |/ /  __/ /    
\__,_/_/ /_/\___/\____/|___/\___/_/

                projectdiscovery.io

[INF] Current uncover version v1.1.0 (latest)
[shodan-idb] 1.1.1.1:53
[shodan-idb] 1.1.1.1:80
[shodan-idb] 1.1.1.1:443
[shodan-idb] 1.1.1.1:2082
[shodan-idb] 1.1.1.1:2086
[shodan-idb] 1.1.1.1:2087
[shodan-idb] 1.1.1.1:8443
[shodan-idb] 1.1.1.1:8880

$ wc -l ff.txt 
       8 ff.txt
```