### PR TITLE
Fixed a bug of hunter agent where improper handling of response data resulted in no output.

### DIFF
--- a/sources/agent/hunter/hunter.go
+++ b/sources/agent/hunter/hunter.go
@@ -67,7 +67,6 @@ func (agent *Agent) Query(session *sources.Session, query *sources.Query) (chan 
 			if numberOfResults >= query.Limit || hunterResponse.Data.Total == 0 || len(hunterResponse.Data.Arr) == 0 {
 				break
 			}
-
 		}
 	}()
 
@@ -83,13 +82,14 @@ func (agent *Agent) query(URL string, session *sources.Session, hunterRequest *R
 
 	hunterResponse := &Response{}
 	RespBodyByBodyBytes, _ := io.ReadAll(resp.Body)
-	if err := json.NewDecoder(resp.Body).Decode(hunterResponse); err != nil {
+	defer func(Body io.ReadCloser) {
+		if bodyCloseErr := Body.Close(); bodyCloseErr != nil {
+			gologger.Info().Msgf("response body close error : %v", bodyCloseErr)
+		}
+	}(resp.Body)
+
+	if err := json.Unmarshal(RespBodyByBodyBytes, hunterResponse); err != nil {
 		result := sources.Result{Source: agent.Name()}
-		defer func(Body io.ReadCloser) {
-			if bodyCloseErr := Body.Close(); bodyCloseErr != nil {
-				gologger.Info().Msgf("response body close error : %v", bodyCloseErr)
-			}
-		}(resp.Body)
 		raw, _ := json.Marshal(RespBodyByBodyBytes)
 		result.Raw = raw
 		results <- result


### PR DESCRIPTION
Fixed the issue of hunter agent where improper handling of response data resulted in no output

- After executing `RespBodyByBodyBytes, _ := io.ReadAll(resp.Body)`, resp.Body will become null, When attempting to use `json.NewDecoder(resp.Body).Decode(hunterResponse)`, no content can be read because the response body has already been completely read, causing the JSON decoding to fail and preventing the program from reaching the subsequent normal processing flow.
- Fixed the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced HTTP response handling to improve resource cleanup and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->