### PR TITLE
add ZOOMEYE_HOST env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ integration-tests/integration-test
 # Dependency directories (remove the comment below to include it)
 # vendor/
 dist/
+
+.idea

--- a/sources/agent/zoomeye/zoomeye.go
+++ b/sources/agent/zoomeye/zoomeye.go
@@ -4,15 +4,16 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"errors"
-
 	"github.com/projectdiscovery/uncover/sources"
 )
 
 var (
-	URL = "https://api.zoomeye.ai/v2/search"
+	Host = sources.GetEnv("ZOOMEYE_HOST", "zoomeye.ai")
+	URL  = fmt.Sprintf("https://api.%s/v2/search", Host)
 )
 
 type Agent struct{}

--- a/sources/util.go
+++ b/sources/util.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"io"
 	"net/url"
+	"os"
 
 	"github.com/projectdiscovery/retryablehttp-go"
 )
@@ -22,4 +23,10 @@ func GetHostname(u string) (string, error) {
 		return "", err
 	}
 	return parsedURL.Hostname(), nil
+}
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
 }


### PR DESCRIPTION
#714
ZoomEye distinguishes between regions within China and those outside China when accessing the API. In China, we use zoomeye.org instead of zoomeye.ai, and their data is not interconnected. I hope to re-add ZOOMEYE_HOST to accommodate users in China


I added ZOOMEYE_HOST to address issues encountered by users in different regions when calling the ZoomEye API!

```sh
ZOOMEYE_HOST="zoomeye.org" ./uncover -q 'title="hello"' -e zoomeye
```
<img width="1728" height="592" alt="image" src="https://github.com/user-attachments/assets/0c4efb94-28bf-40b1-adca-b3fbdd0d913d" />
