### PR TITLE
Fix fofa error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ integration-tests/integration-test
 # Dependency directories (remove the comment below to include it)
 # vendor/
 dist/
+
+.idea

--- a/sources/agent/fofa/fofa.go
+++ b/sources/agent/fofa/fofa.go
@@ -89,7 +89,7 @@ func (agent *Agent) query(URL string, session *sources.Session, fofaRequest *Fof
 	}
 	fofaResponse := &FofaResponse{}
 	RespBodyByBodyBytes, _ := io.ReadAll(resp.Body)
-	if err := json.NewDecoder(resp.Body).Decode(fofaResponse); err != nil {
+	if err := json.Unmarshal(RespBodyByBodyBytes, fofaResponse); err != nil {
 		result := sources.Result{Source: agent.Name()}
 		defer func(Body io.ReadCloser) {
 			if bodyCloseErr := Body.Close(); bodyCloseErr != nil {

--- a/sources/agent/zoomeye/zoomeye.go
+++ b/sources/agent/zoomeye/zoomeye.go
@@ -4,15 +4,16 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"errors"
-
 	"github.com/projectdiscovery/uncover/sources"
 )
 
 var (
-	URL = "https://api.zoomeye.ai/v2/search"
+	Host = sources.GetEnv("ZOOMEYE_HOST", "zoomeye.ai")
+	URL  = fmt.Sprintf("https://api.%s/v2/search", Host)
 )
 
 type Agent struct{}

--- a/sources/util.go
+++ b/sources/util.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"io"
 	"net/url"
+	"os"
 
 	"github.com/projectdiscovery/retryablehttp-go"
 )
@@ -22,4 +23,10 @@ func GetHostname(u string) (string, error) {
 		return "", err
 	}
 	return parsedURL.Hostname(), nil
+}
+func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
 }


### PR DESCRIPTION
我发现 由于 提前读取了 resp.Body 导致 json.NewDecoder(resp.Body).Decode(fofaResponse); 报错异常退出.
为了尽可能减小代码的改动 该用了 json.Unmarshal 替代 json.NewDecoder