### PR TITLE
chore: add missing metadata, cve-id, and nvd reference

### DIFF
--- a/sources/agent.go
+++ b/sources/agent.go
@@ -1,11 +1,29 @@
 package sources
 
+// AccountInfo holds credit or usage information for a provider.
+type AccountInfo struct {
+	Plan         string
+	QueriesLeft  int
+	Raw          string
+}
+
+// Query represents the search parameters for the agents.
 type Query struct {
 	Query string
 	Limit int
 }
 
+// Agent is the basic interface for all search engines.
 type Agent interface {
+	// Query performs the search and returns a channel of results.
 	Query(*Session, *Query) (chan Result, error)
+	// Name returns the provider name.
 	Name() string
+}
+
+// InfoAgent is an interface for agents that support checking balance/account info.
+type InfoAgent interface {
+	Agent
+	// Info retrieves account-specific information like remaining credits.
+	Info(*Session) (*AccountInfo, error)
 }


### PR DESCRIPTION
"I have updated the InfoAgent interface to return a structured AccountInfo type instead of a raw string, as suggested. I also added detailed docstrings to the interfaces to improve code maintainability. This ensures a consistent way to handle credit/balance data across different providers like Shodan and Censys. Ready for another look! 🚀"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account information retrieval now available, displaying subscription plan and remaining query quota.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->