### PR TITLE
fix: dedup json output by host+url when ip and port are empty

### DIFF
--- a/runner/output_writer.go
+++ b/runner/output_writer.go
@@ -63,7 +63,13 @@ func (o *OutputWriter) WriteString(data string) {
 
 // WriteJsonData writes the result taken as input in JSON format
 func (o *OutputWriter) WriteJsonData(data sources.Result) {
-	if o.findDuplicate(fmt.Sprintf("%s:%d", data.IP, data.Port), true) {
+	var key string
+	if data.IP != "" || data.Port != 0 {
+		key = fmt.Sprintf("%s:%d", data.IP, data.Port)
+	} else {
+		key = data.Host + "|" + data.Url
+	}
+	if o.findDuplicate(key, true) {
 		return
 	}
 	o.Write([]byte(data.JSON()))

--- a/runner/output_writer.go
+++ b/runner/output_writer.go
@@ -64,10 +64,10 @@ func (o *OutputWriter) WriteString(data string) {
 // WriteJsonData writes the result taken as input in JSON format
 func (o *OutputWriter) WriteJsonData(data sources.Result) {
 	var key string
-	if data.IP != "" || data.Port != 0 {
+	if data.IP != "" && data.Port != 0 {
 		key = fmt.Sprintf("%s:%d", data.IP, data.Port)
 	} else {
-		key = data.Host + "|" + data.Url
+		key = fmt.Sprintf("%q|%d|%q|%q", data.IP, data.Port, data.Host, data.Url)
 	}
 	if o.findDuplicate(key, true) {
 		return


### PR DESCRIPTION
## Summary

`-j` (JSON output) only printed the first result for sources that don't return IP info (e.g. `nerdydata`).

### Root cause

`OutputWriter.WriteJsonData` was deduping results using `fmt.Sprintf("%s:%d", IP, Port)`. For sources where IP is empty and Port is 0, every result hashed to the same key `:0`, so all results after the first were dropped as duplicates.

### Repro (before fix)

```
$ ./uncover -nerdydata jquery -silent -limit 10 -j
{"timestamp":...,"source":"nerdydata","ip":"","port":0,"host":"cloudflare.com","url":"https://www.cloudflare.com/"}
# (only one line)
```

### Fix

Pick the dedup key based on what's populated:
- If IP or Port is set → key is `IP:Port` (preserves existing behaviour for shodan/censys/fofa, where two sources finding the same service should collapse into one row).
- Else → key is `Host|Url` (covers nerdydata and any future source that returns hosts/URLs only).

### After fix

```
$ ./uncover -nerdydata jquery -silent -limit 10 -j
{...host:"cloudflare.com"...}
{...host:"wordpress.org"...}
{...host:"bootstrapcdn.com"...}
{...host:"jquery.com"...}
{...host:"amazonaws.com"...}
{...host:"mozilla.org"...}
{...host:"fontawesome.com"...}
{...host:"medium.com"...}
{...host:"creativecommons.org"...}
{...host:"bbc.co.uk"...}
```

## Test plan

- [x] `./uncover -nerdydata jquery -silent -limit 10 -j` prints all 10 results
- [x] `./uncover -nerdydata jquery -silent -limit 10` (non-JSON) still prints all 10 (unchanged code path)
- [ ] Verify shodan/censys IP:port dedup still collapses duplicates across sources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deduplication to avoid incorrectly skipping entries when port information is missing by using alternative identifiers (IP, host, URL) so unique records are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->