### PR TITLE
Fix install instruction to reference @main instead of @latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 uncover requires **go1.21** to install successfully. Run the following command to get the repo -
 
 ```sh
-go install -v github.com/projectdiscovery/uncover/cmd/uncover@latest
+go install -v github.com/projectdiscovery/uncover/cmd/uncover@main
 ```
 
 ## Usage


### PR DESCRIPTION
`go install -v github.com/projectdiscovery/uncover/cmd/uncover@latest` didn't pick up the actual latest version.

`go install -v github.com/projectdiscovery/uncover/cmd/uncover@main` had the correct latest release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to use the `main` branch during the installation process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/projectdiscovery/uncover/pull/733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->